### PR TITLE
Add basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:bookworm
+
+RUN \
+	apt-get update && \
+	apt-get upgrade && \
+	apt-get install -y sbcl curl gcc gpg && \
+	apt-get clean && \
+	cd /root && \
+	curl -O https://beta.quicklisp.org/quicklisp.lisp && \
+	curl -O https://beta.quicklisp.org/quicklisp.lisp.asc && \
+	curl -O https://beta.quicklisp.org/release-key.txt && \
+	gpg --import release-key.txt && \
+	gpg --verify quicklisp.lisp.asc quicklisp.lisp && \
+	rm -rf /root/quicklisp.lisp.asc /root/release-key.txt && \
+	sbcl --load /root/quicklisp.lisp --eval '(quicklisp-quickstart:install)' --eval '(ql-util:without-prompting (ql:add-to-init-file))'
+
+WORKDIR /app
+
+ENTRYPOINT ["/app/docker_build.sh"]

--- a/README.mess
+++ b/README.mess
@@ -32,3 +32,13 @@ ldapper import <(slapcat -b "dc=example,dc=com")
 (note the ``--dry-run`` flag for that)
 
 And that's pretty much it. For more information, see the help as described above.
+
+## Docker build instructions
+
+::
+docker build -t ldapper .
+
+docker run --rm -it -v "$PWD:/app" ldapper
+::
+
+This will build the `ldapper` binary in the current directory.

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec sbcl --eval '(require "asdf")' --eval '(asdf:load-asd "/app/ldapper.asd")' --eval '(ql:quickload :ldapper)' --eval '(asdf:make :ldapper)'


### PR DESCRIPTION
I didn't want to reinvent the roswell Dockerfiles at fukamachi/dockerfiles but I could not get them to work at all, maybe it's something with sbcl 2.4.4 being auto-installed.

This should be enough to get interested people to get it to build and hack on it if they don't know their way around SBCL, just as I only wanted to play around a bit and wanted to compile it first.

At the time of writing this uses SBCL 2.2.9.